### PR TITLE
[3.2] abieos: Fix compile warning -- throw will always call terminate()

### DIFF
--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -5,7 +5,11 @@
 
 #include <memory>
 
-inline const bool catch_all = true;
+#ifdef ABIEOS_NOT_CATCH_ALL
+constexpr bool catch_all = false;
+#else
+constexpr bool catch_all = true;
+#endif
 
 using namespace abieos;
 
@@ -36,12 +40,12 @@ auto handle_exceptions(abieos_context* context, T errval, F f) noexcept -> declt
     try {
         return f();
     } catch (std::exception& e) {
-        if (!catch_all)
+        if constexpr (!catch_all)
             throw;
         set_error(context, e.what());
         return errval;
     } catch (...) {
-        if (!catch_all)
+        if constexpr (!catch_all)
             throw;
         set_error(context, "unknown exception");
         return errval;
@@ -52,7 +56,7 @@ extern "C" abieos_context* abieos_create() {
     try {
         return new abieos_context{};
     } catch (...) {
-        if (!catch_all)
+        if constexpr (!catch_all)
             throw;
         return nullptr;
     }

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -5,12 +5,6 @@
 
 #include <memory>
 
-#ifdef ABIEOS_NOT_CATCH_ALL
-constexpr bool catch_all = false;
-#else
-constexpr bool catch_all = true;
-#endif
-
 using namespace abieos;
 
 struct abieos_context_s {
@@ -40,13 +34,9 @@ auto handle_exceptions(abieos_context* context, T errval, F f) noexcept -> declt
     try {
         return f();
     } catch (std::exception& e) {
-        if constexpr (!catch_all)
-            throw;
         set_error(context, e.what());
         return errval;
     } catch (...) {
-        if constexpr (!catch_all)
-            throw;
         set_error(context, "unknown exception");
         return errval;
     }
@@ -56,8 +46,6 @@ extern "C" abieos_context* abieos_create() {
     try {
         return new abieos_context{};
     } catch (...) {
-        if constexpr (!catch_all)
-            throw;
         return nullptr;
     }
 }


### PR DESCRIPTION
Resolve https://github.com/eosnetworkfoundation/mandel-abieos/issues/5

`abieos.cpp` produces 120 occurrences of the following warnings:
```
tests/abieos/src/abieos.cpp:40:13: warning: throw will always call terminate() [-Wterminate]
tests/abieos/src/abieos.cpp:45:13: warning: throw will always call terminate() [-Wterminate]
```
The offending code is
 ```
if (!catch_all)
    throw;
```
while `catch_all` is defined as ` inline const bool catch_all = true;`

The solution is,  make `catch_all` constexpr, check if a preprocessor `ABIEOS_NOT_CATCH_ALL` is defined and set `catch_all` true or false accordingly; and do `if constexpr`.

After the changes, no more warnings are generated from `aieos.cpp`.

