### PR TITLE
fix ship_protocol.hpp for 2.0.x & 3.1.x

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -156,14 +156,6 @@ struct secondary_index_def {
 
 EOSIO_REFLECT(secondary_index_def, type);
 
-struct kv_table_entry_def {
-   std::string                                type;
-   primary_key_index_def                      primary_index;
-   std::map<eosio::name, secondary_index_def> secondary_indices;
-};
-
-EOSIO_REFLECT(kv_table_entry_def, type, primary_index, secondary_indices);
-
 struct abi_def {
    std::string                                                version{};
    std::vector<type_def>                                      types{};
@@ -175,11 +167,10 @@ struct abi_def {
    abi_extensions_type                                        abi_extensions{};
    might_not_exist<std::vector<variant_def>>                  variants{};
    might_not_exist<std::vector<action_result_def>>            action_results{};
-   might_not_exist<std::map<eosio::name, kv_table_entry_def>> kv_tables{};
 };
 
 EOSIO_REFLECT(abi_def, version, types, structs, actions, tables, ricardian_clauses, error_messages, abi_extensions,
-              variants, action_results, kv_tables);
+              variants, action_results);
 
 struct abi_type;
 
@@ -254,7 +245,6 @@ struct abi_type {
 struct abi {
    std::map<eosio::name, std::string> action_types;
    std::map<eosio::name, std::string> table_types;
-   std::map<eosio::name, std::string> kv_tables;
    std::map<std::string, abi_type>    abi_types;
    std::map<eosio::name, std::string> action_result_types;
    const abi_type*                    get_type(const std::string& name);
@@ -387,7 +377,6 @@ void to_json(const abi_def& def, S& stream) {
    to_json_write_helper(def.error_messages, "error_messages", true, stream);
    to_json_write_helper(def.variants.value, "variants", true, stream);
    to_json_write_helper(def.action_results.value, "action_results", true, stream);
-   to_json_write_helper(def.kv_tables.value, "kv_tables", true, stream);
    stream.write('}');
 }
 } // namespace eosio

--- a/include/eosio/ship_protocol.hpp
+++ b/include/eosio/ship_protocol.hpp
@@ -638,14 +638,6 @@ namespace eosio { namespace ship_protocol {
 
    EOSIO_REFLECT(global_property_v1, proposed_schedule_block_num, proposed_schedule, configuration, chain_id, wasm_configuration)
 
-   struct kv_database_config {
-      uint32_t max_key_size   = 0; ///< the maximum size in bytes of a key
-      uint32_t max_value_size = 0; ///< the maximum size in bytes of a value
-      uint32_t max_iterators  = 0; ///< the maximum number of iterators that a contract can have simultaneously.
-   };
-
-   EOSIO_REFLECT(kv_database_config, max_key_size, max_value_size, max_iterators)
-
    using global_property = std::variant<global_property_v0, global_property_v1>;
 
    struct generated_transaction_v0 {

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -193,13 +193,6 @@ void eosio::convert(const abi_def& abi, eosio::abi& c) {
     for (auto& [_, t] : c.abi_types) {
         fill(c.abi_types, t, 0);
     }
-
-    for (const auto& [key, val] : abi.kv_tables.value) {
-        std::vector<char> bytes;
-        eosio::vector_stream strm(bytes);
-        to_json(val, strm);
-        c.kv_tables.try_emplace(key, bytes.begin(), bytes.end());
-    }
 }
 
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::builtin&) {}

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -181,21 +181,6 @@ extern "C" const char* abieos_get_type_for_table(abieos_context* context, uint64
     });
 }
 
-extern "C" const char* abieos_get_kv_table_def(abieos_context* context, uint64_t contract, uint64_t table) {
-    return handle_exceptions(context, nullptr, [&] {
-        auto contract_it = context->contracts.find(::abieos::name{contract});
-        if (contract_it == context->contracts.end())
-            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" is not loaded");
-        auto& c = contract_it->second;
-
-        auto table_it = c.kv_tables.find(name{table});
-        if (table_it == c.kv_tables.end())
-            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" does not have kv table \"" +
-                                     eosio::name_to_string(table) + "\"");
-        return table_it->second.c_str();
-    });
-}
-
 extern "C" const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract,
                                                          uint64_t action_result) {
     return handle_exceptions(context, nullptr, [&] {

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -52,10 +52,6 @@ const char* abieos_get_type_for_action(abieos_context* context, uint64_t contrac
 // to retrieve error.
 const char* abieos_get_type_for_table(abieos_context* context, uint64_t contract, uint64_t table);
 
-// Get the definition for a kv table in json. The context owns the returned memory. Returns null on error; use
-// abieos_get_error to retrieve error.
-const char* abieos_get_kv_table_def(abieos_context* context, uint64_t contract, uint64_t table);
-
 // Get the type name for an action_result. The context owns the returned memory. Returns null on error; use
 // abieos_get_error to retrieve error.
 const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result);

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -368,24 +368,7 @@ const char testKvTablesAbi[] = R"({
             "ricardian_contract": ""
         }
     ],
-    "tables": [],
-    "kv_tables": {
-        "testtable": {
-            "type": "my_struct",
-            "primary_index": {
-                "name": "primary",
-                "type": "name"
-            },
-            "secondary_indices": {
-                "foo": {
-                    "type": "string"
-                },
-                "bar": {
-                    "type": "uint64"
-                }
-            }
-        }
-    }
+    "tables": []
 })";
 
 const char packedTransactionAbi[] = R"({
@@ -1234,12 +1217,6 @@ void check_types() {
     testWith(testAbiName);
     testWith(testHexAbiName);
 
-    std::string table_def = check_context(
-        context, abieos_get_kv_table_def(context, testKvAbiName, abieos_string_to_name(context, "testtable")));
-    if (table_def !=
-        R"({"type":"my_struct","primary_index":{"name":"primary","type":"name"},"secondary_indices":{"bar":{"type":"uint64"},"foo":{"type":"string"}}})")
-        throw std::runtime_error("mismatch");
-
     auto check_checksum_capacity = [&](const auto& checksum, size_t capacity, const char* msg) {
         if(checksum.capacity() != capacity)
             throw std::runtime_error(std::string{msg} + " capacity test failed");
@@ -1256,125 +1233,10 @@ void check_types() {
     abieos_destroy(context);
 }
 
-void test_abi_kv_table() {
-    using namespace std;
-    std::vector<std::string> version_list{"eosio::abi/1.0", "eosio::abi/1.1"};
-
-    // empty abi_def
-    {
-        for(const auto& ver : version_list) {
-           abieos_context* abi_cnxt = abieos_create();
-           abieos::abi_def empty_abi_def;
-           empty_abi_def.version = ver;
-           std::vector<char> bytes;
-           eosio::vector_stream byte_stream(bytes);
-           to_json(empty_abi_def, byte_stream);
-           const std::string empty_abi_def_json(bytes.begin(), bytes.end());
-           if (!abieos_abi_json_to_bin(abi_cnxt, empty_abi_def_json.c_str())) {
-              printf("test_abi_kv_table: %s\n", abieos_get_error(abi_cnxt));
-              throw std::runtime_error("test_abi_kv_table: Failed to convert empty_abi_def_json (json) to bin");
-           }
-           printf("test_abi_kv_table: Successfully converted empty_abi_def_json to bin :\n%s\n", empty_abi_def_json.c_str());
-
-           const int bin_data_size = abieos_get_bin_size(abi_cnxt);
-           printf("test_abi_kv_table: Get empty_abi_def_json (bin) data size: %d\n", bin_data_size);
-
-           const char* abi_bin_data = abieos_get_bin_data(abi_cnxt);
-
-           const char* abi_json_data = abieos_abi_bin_to_json(abi_cnxt, abi_bin_data, bin_data_size);
-           if (abi_json_data == nullptr) {
-              throw std::runtime_error("empty_abi_def_json: Failed to convert testKvTablesAbi (bin) to json");
-           }
-           printf("test_abi_kv_table: Successfully converted empty_abi_def_json (bin) to json:\n%s\n", abi_json_data);
-
-           rapidjson::Document orig_json;
-           orig_json.Parse(empty_abi_def_json.c_str());
-           rapidjson::StringBuffer orig_buf;
-           rapidjson::Writer<rapidjson::StringBuffer> orig_writer(orig_buf);
-           orig_json.Accept(orig_writer);
-
-           rapidjson::Document cvtd_json;
-           cvtd_json.Parse(abi_json_data);
-           rapidjson::StringBuffer cvtd_buf;
-           rapidjson::Writer<rapidjson::StringBuffer> cvtd_writer(cvtd_buf);
-           cvtd_json.Accept(cvtd_writer);
-           if (strcmp(orig_buf.GetString(), cvtd_buf.GetString())) {
-              throw std::runtime_error("test_abi_kv_table: Converted empty_abi_def_json json is different from orig");
-           }
-           abieos_destroy(abi_cnxt);
-        }
-    }
-    // every field o abi_def has some value
-    {
-       for(const auto& ver : version_list) {
-          abieos_context *abi_cnxt = abieos_create();
-          abieos::abi_def all_abi_def;
-          all_abi_def.version = ver;
-          all_abi_def.types.push_back({"t_new_type_1", "t_type1"});
-          all_abi_def.structs.push_back(eosio::struct_def{""});
-          all_abi_def.structs.push_back(
-                eosio::struct_def{"s_name1", "s_base1", {eosio::field_def{"f_name1", "f_type1"}}});
-          all_abi_def.actions.push_back(eosio::action_def{eosio::name{"name1"}, "a_type1", "a_rc_1"});
-          all_abi_def.tables.push_back(
-                eosio::table_def{eosio::name{"tname1"}, "idx_type1", {"k_name_1"}, {"k_type1"}, {"t_type1"}});
-          all_abi_def.ricardian_clauses.push_back(eosio::clause_pair{"cp_id_1", "cp_body_1"});
-          all_abi_def.error_messages.push_back(eosio::error_message{1234567890, "msg1"});
-          // Ignore abi_extensions in to_json and from_json
-          all_abi_def.variants.value.push_back(eosio::variant_def{"v_name1", {"v_type1"}});
-          all_abi_def.action_results.value.push_back(eosio::action_result_def{eosio::name{"aname1"}, {"a_type1"}});
-          eosio::kv_table_entry_def kv_def{"kv_type1", eosio::primary_key_index_def{eosio::name{"pki1"}, "kv_type1"},
-                                           {}};
-          kv_def.secondary_indices[eosio::name{"sec2"}] = eosio::secondary_index_def{"sid2"};
-          all_abi_def.kv_tables.value[eosio::name{"kv1"}] = kv_def;
-
-          std::vector<char> bytes;
-          eosio::vector_stream byte_stream(bytes);
-          to_json(all_abi_def, byte_stream);
-          const std::string all_abi_def_json(bytes.begin(), bytes.end());
-
-          if (!abieos_abi_json_to_bin(abi_cnxt, all_abi_def_json.c_str())) {
-             printf("test_abi_kv_table: %s\n", abieos_get_error(abi_cnxt));
-             throw std::runtime_error("test_abi_kv_table: Failed to convert all_abi_def_json (json) to bin");
-          }
-          printf("test_abi_kv_table: Successfully converted all_abi_def_json (json) to bin\n:%s\n", all_abi_def_json.c_str());
-
-          const int bin_data_size = abieos_get_bin_size(abi_cnxt);
-          printf("test_abi_kv_table: Get all_abi_def_json (bin) data size: %d\n", bin_data_size);
-
-          const char *abi_bin_data = abieos_get_bin_data(abi_cnxt);
-
-          const char *abi_json_data = abieos_abi_bin_to_json(abi_cnxt, abi_bin_data, bin_data_size);
-          if (abi_json_data == nullptr) {
-             throw std::runtime_error("all_abi_def_json: Failed to convert testKvTablesAbi (bin) to json");
-          }
-          printf("test_abi_kv_table: Successfully converted all_abi_def_json (bin) to json:\n%s\n", abi_json_data);
-
-          rapidjson::Document orig_json;
-          orig_json.Parse(all_abi_def_json.c_str());
-          rapidjson::StringBuffer orig_buf;
-          rapidjson::Writer <rapidjson::StringBuffer> orig_writer(orig_buf);
-          orig_json.Accept(orig_writer);
-
-          rapidjson::Document cvtd_json;
-          cvtd_json.Parse(abi_json_data);
-          rapidjson::StringBuffer cvtd_buf;
-          rapidjson::Writer <rapidjson::StringBuffer> cvtd_writer(cvtd_buf);
-          cvtd_json.Accept(cvtd_writer);
-          if (strcmp(orig_buf.GetString(), cvtd_buf.GetString())) {
-             throw std::runtime_error("test_abi_kv_table: Converted all_abi_def_json json is different from orig");
-          }
-          abieos_destroy(abi_cnxt);
-       }
-    }
-}
-
 int main() {
     try {
         check_types();
         printf("\ncheck_types ok\n\n");
-
-        test_abi_kv_table();
-        printf("\ntest_abi_kv_table: ok\n\n");
         return 0;
     } catch (std::exception& e) {
         printf("error: %s\n", e.what());


### PR DESCRIPTION
These changes are known to fix ship_protocol.hpp for 2.0.x and 3.1.x (it is correct for _neither_ currently). However, I don't believe it's an exhaustive removal (for example ship.abi.cpp used by tests is still incorrect). This PR likely conflicts with #8